### PR TITLE
Clarify the readme doc about UD-specific components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.9
+
+- Clarify the readme doc about UD-specific components
+
 ### 0.1.8
 
 - Fix readme code snippet

--- a/README.md
+++ b/README.md
@@ -96,25 +96,15 @@ const App = () => {
 }
 ```
 
-### Importing UD components
+### Importing UD-specific components
 
-Common components used at
-[Unstoppable Domains website](https://unstoppabledomains.com/) will be provided
-at the root import path soon.
+Some components are very different from MUI components, in such cases they will have unique names
+not to conflict with MUI convention. Example: `DomainSearchCard`. As a result such components
+will be documented with Storybook with a specific set of props.
 
-Once a UD component whose name collides with a MUI component name becomes
-available for importing at `@unstoppabledomains/ui-kit` path, the MUI component
-becomes overwritten with the styled version used at UD.
-
-For example, considering `Alert` component has been implemented at UI Kit, and
-`Link` has not:
-
-```typescript
-import {
-  Alert, // UD version is ready and MUI version is not available anymore
-  Link, // UD version is not ready yet so MUI version is imported instead
-} from '@unstoppabledomains/ui-kit';
-```
+There are cases when UD & MUI components have similarities, such as `Modal` or `Button`. In such
+cases UD will inherit MUI component props and will extend them to support UD-specific props. New
+props will be documented in Storybook, with a reference to the MUI component documentation.
 
 ## Development and contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-kit",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "A set of common Unstoppable Domains components",
   "keywords": [


### PR DESCRIPTION
I'd like to clarify an approach of extending MUI props, rather than radically changing MUI APIs. We will have hybrid components with lots of similarities and it would be best to inherit MUI functionality for such components.