### PR TITLE
Set enterTouchDelay prop default value to 0 for MuiTooltip component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.3.8
+
+- Set `enterTouchDelay` prop default value to `0` for `MuiTooltip` component
+
 ### 0.3.7
 
 - Remove `CryptoCom` crypto icon

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-kit",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": false,
   "description": "A set of common Unstoppable Domains components",
   "keywords": [

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -418,6 +418,11 @@ const buildThemeOptions = (mode: 'light' | 'dark'): ThemeOptions => ({
 const addThemeOverrides = (theme: Theme) => {
   /* eslint-disable no-param-reassign */
   theme.components = {
+    MuiTooltip: {
+      defaultProps: {
+        enterTouchDelay: 0,
+      },
+    },
     MuiTabs: {
       defaultProps: {
         textColor: 'primary',


### PR DESCRIPTION
The default value for `enterTouchDelay` prop of `MuiTooltip` component is `700` which makes it require a long tap on mobile to appear. This PR sets `enterTouchDelay` prop default value to `0` for `MuiTooltip` component for better UX on mobile on the global UD theme level.