### PR TITLE
Add support for HTML content inside Alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.3.9
+
+- Adds support for HTML content inside `Alert` component
+
 ### 0.3.8
 
 - Set `enterTouchDelay` prop default value to `0` for `MuiTooltip` component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-kit",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": false,
   "description": "A set of common Unstoppable Domains components",
   "keywords": [

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -32,7 +32,7 @@ export default {
 const textProps = {
   warning: {
     heading: 'Please fill IPFS hash input to launch website',
-    body: 'Don’t worry, we are actively working on developing Android App for our users.',
+    body: 'Don’t worry, we are actively working on developing <strong>Android</strong> App for our users.',
   },
   error: {
     heading: 'Unable to detect a web3 wallet',
@@ -45,7 +45,7 @@ const textProps = {
   info: {
     heading:
       "Please select another method for claiming if you can't use iOS app",
-    body: 'Don’t worry, we are actively working on developing Android App for our users.',
+    body: 'Don’t worry, we are actively working on developing <strong>Android</strong> App for our users.',
   },
 };
 

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -72,8 +72,13 @@ const Alert: FC<AlertProps> = ({
           {heading}
         </MuiAlertTitle>
       )}
-      {!!children && (
-        <div className={cx(classes.body, props.classes?.body)}>{children}</div>
+      {Boolean(children) && (
+        <div
+          className={cx(classes.body, props.classes?.body)}
+          {...(typeof children === 'string'
+            ? {dangerouslySetInnerHTML: {__html: children}}
+            : {children})}
+        />
       )}
     </MuiAlert>
   );


### PR DESCRIPTION
Adds support for HTML content inside `Alert` component.

<img width="683" alt=" Alert - Default ⋅ Storybook 2023-06-05 23-10-43" src="https://github.com/unstoppabledomains/UI-Kit/assets/325422/dad212b6-cff4-469b-a410-2de0fe8f7eaf">
